### PR TITLE
Added microdata to event output

### DIFF
--- a/_multipack/multipack.php
+++ b/_multipack/multipack.php
@@ -222,22 +222,32 @@
       $raw_meetup = explode('-',  $raw_event['slug']);
       $meetup = $raw_meetup[0];
 
-      // And the date
-      $raw_date = explode('-', $raw_event['start_date']);
-      $date = date('j M', mktime(0, 0, 0, $raw_date[1], $raw_date[2], $raw_date[0]));
-
-      // And the location
-      $raw_location = explode(',', $raw_event['place_name']);
-
+      // What hours do the events start at?
       $times = array(
+        "multipack" => "14:00:00",
+        "leampack" => "19:30:00"
+      );
+      
+      // This should be the responsiiblity of the view layer really
+      $display_times = array(
         "multipack" => "2pm",
         "leampack" => "7:30pm"
       );
 
+      $datetime = $raw_event['start_date'];
+      if (isset( $times[$meetup] )) {
+        $datetime = $raw_event['start_date'] . ' ' . $times[$meetup];
+      }
+      $datetime = new DateTime($datetime, new DateTimeZone('Europe/London'));
+
+      // And the location
+      $raw_location = explode(',', $raw_event['place_name']);
+
       $event = array(
         "meetup" => $meetup,
-        "date" => $date,
-        "time" => $times[$meetup],
+        "date" => $datetime->format('j M'),
+        "time" => isset( $display_times[$meetup] ) ? $display_times[$meetup] : '',
+        "datetime" => $datetime->format('c'), // ISO 8601
         "venue" => $raw_event['venues'][0],
         "location" => $raw_location[0],
         "lanyrd" => $raw_event['web_url'],

--- a/_multipack/view/event.php
+++ b/_multipack/view/event.php
@@ -22,26 +22,31 @@
 
 */ ?>
 
-<article role="details">
-  <h2 class="type"><?=$view_component_data->meetup?></h2>
-  <h2 class="date"><?=$view_component_data->date?></h2>
-  <h2 class="venue"><?=$view_component_data->venue['name']?></h2>
-  <h2 class="location"><?=$view_component_data->location?></h2>
-  <h2 class="time"><?=$view_component_data->time?></h2>
-</article>
-<p class="synopsis extra"><?=$view_component_data->tagline?></p>
-<div class="map iframe">
-  <iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="<?=$view_component_data->map_url?>&amp;output=embed"></iframe>
+<div itemscope itemtype="http://schema.org/SocialEvent/Meetup">
+  <article role="details">
+    <h2 class="type" itemprop="name"><?=$view_component_data->meetup?></h2>
+    <h2 class="date"><time itemprop="startDate" datetime="<?=$view_component_data->datetime?>"><?=$view_component_data->date?></time></h2>
+    <div class="location" itemprop="location" itemscope itemtype="http://schema.org/Place">
+      <h2 class="venue" itemprop="name"><?=$view_component_data->venue['name']?></h2>
+      <h2 class="region" itemprop="containedIn" itemscope itemtype="http://schema.org/AdministrativeArea"><span itemprop="name"><?=$view_component_data->location?></span></h2>
+      <meta itemprop="map" content="<?=$view_component_data->map_url?>">
+    </div>
+    <h2 class="time"><?=$view_component_data->time?></h2>
+  </article>
+  <p class="synopsis extra"><?=$view_component_data->tagline?></p>
+  <div class="map iframe">
+    <iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="<?=$view_component_data->map_url?>&amp;output=embed"></iframe>
+  </div>
+  <div class="map mapimage">
+    <a href="<?=$view_component_data->map_url?>"><img src="http://maps.google.com/maps/api/staticmap?center=<?=$view_component_data->venue['latitude']?>,<?=$view_component_data->venue['longitude']?>&amp;zoom=15&amp;size=425x350&amp;sensor=false&amp;markers=size:mid|color:blue|<?=$view_component_data->venue['latitude']?>,<?=$view_component_data->venue['longitude']?>"></a>
+  </div>
+  <nav role="more">
+    <ul>
+      <li class="findmore"><a href="#">More Info</a></li>
+      <li class="eventfocus"><a href="/<?=$view_component_data->url?>" itemprop="url">Map &amp; Details</a></li>
+      <li><a href="<?=$view_component_data->lanyrd?>">Lanyrd</a></li>
+      <li><a href="//twitter.com/<?=$view_component_data->meetup?>">Twitter</a></li>
+      <li class="findless"><a href="#">Close</a></li>
+    </ul>
+  </nav>
 </div>
-<div class="map mapimage">
-  <a href="<?=$view_component_data->map_url?>"><img src="http://maps.google.com/maps/api/staticmap?center=<?=$view_component_data->venue['latitude']?>,<?=$view_component_data->venue['longitude']?>&amp;zoom=15&amp;size=425x350&amp;sensor=false&amp;markers=size:mid|color:blue|<?=$view_component_data->venue['latitude']?>,<?=$view_component_data->venue['longitude']?>"></a>
-</div>
-<nav role="more">
-  <ul>
-    <li class="findmore"><a href="#">More Info</a></li>
-    <li class="eventfocus"><a href="/<?=$view_component_data->url?>">Map &amp; Details</a></li>
-    <li><a href="<?=$view_component_data->lanyrd?>">Lanyrd</a></li>
-    <li><a href="//twitter.com/<?=$view_component_data->meetup?>">Twitter</a></li>
-    <li class="findless"><a href="#">Close</a></li>
-  </ul>
-</nav>

--- a/_multipack/view/upcoming.php
+++ b/_multipack/view/upcoming.php
@@ -35,7 +35,7 @@
     <ul>
     <?php foreach( $this->view_data->events as $event ): ?>
 
-      <li role="event" class="folded <?=$event->meetup?> event">
+      <li class="folded <?=$event->meetup?> event">
         <header>
           <h1>Multipack</h1>
           <p>Upcoming Event:</p>

--- a/css/less/colour.less
+++ b/css/less/colour.less
@@ -137,7 +137,7 @@ header nav {
   h2 {
     color: @color;
   }
-  .date, .location, .synopsis {
+  .date, .region, .synopsis {
     color: @section-nav-link-bg-dark;
   }
 }
@@ -180,7 +180,7 @@ header nav {
     color: @multipack-color;
   }
   &.event {
-    .date, .location, .synopsis {
+    .date, .region, .synopsis {
       color: @multipack-alternate;
     }
     .type {
@@ -227,7 +227,7 @@ header nav {
     color: @leampack-color;
   }
   &.event {
-    .date, .location, .synopsis {
+    .date, .region, .synopsis {
       color: @leampack-alternate;
     }
     .type {
@@ -268,7 +268,7 @@ header nav {
 //     color: @staffspack-color;
 //   }
 //   &.event {
-//     .date, .location, .synopsis {
+//     .date, .region, .synopsis {
 //       color: @staffspack-alternate;
 //     }
 //     .type {
@@ -312,7 +312,7 @@ header nav {
     color: @presents-color;
   }
   &.event {
-    .date, .location, .synopsis {
+    .date, .region, .synopsis {
       color: @presents-alternate;
     }
     .type {

--- a/css/less/main.less
+++ b/css/less/main.less
@@ -63,6 +63,10 @@ section > article {
     text-transform: uppercase;
   }
 
+  .location {
+    display: inline;
+  }
+
   &.focus {
     border-top: .1875em solid white;
 
@@ -101,7 +105,7 @@ section > article {
     float: left;
     margin-right: 0.667em;
   }
-  .time, .location, .extra, .map {
+  .time, .region, .extra, .map {
     .visuallyhidden;
   }
   nav {

--- a/css/style.css
+++ b/css/style.css
@@ -1,216 +1,1241 @@
-article,aside,details,figcaption,figure,footer,header,hgroup,nav,section{display:block;}
-audio,canvas,video{display:inline-block;*display:inline;*zoom:1;}
-audio:not([controls]){display:none;}
-[hidden]{display:none;}
-html{font-size:100%;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;}
-html,button,input,select,textarea{font-family:sans-serif;color:#222222;}
-body{margin:0;font-size:1em;line-height:1.4;}
-::-moz-selection{background:#fe57a1;color:#fff;text-shadow:none;}
-::selection{background:#fe57a1;color:#fff;text-shadow:none;}
-a{color:#0000ee;}
-a:visited{color:#551a8b;}
-a:hover{color:#0066ee;}
-a:focus{outline:thin dotted;}
-a:hover,a:active{outline:0;}
-abbr[title]{border-bottom:1px dotted;}
-b,strong{font-weight:bold;}
-blockquote{margin:1em 40px;}
-dfn{font-style:italic;}
-hr{display:block;height:1px;border:0;border-top:1px solid #ccc;margin:1em 0;padding:0;}
-ins{background:#ff9;color:#000;text-decoration:none;}
-mark{background:#ff0;color:#000;font-style:italic;font-weight:bold;}
-pre,code,kbd,samp{font-family:monospace,serif;_font-family:'courier new',monospace;font-size:1em;}
-pre{white-space:pre;white-space:pre-wrap;word-wrap:break-word;}
-q{quotes:none;}
-q:before,q:after{content:"";content:none;}
-small{font-size:85%;}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline;}
-sup{top:-0.5em;}
-sub{bottom:-0.25em;}
-ul,ol{margin:1em 0;padding:0 0 0 40px;}
-dd{margin:0 0 0 40px;}
-nav ul,nav ol{list-style:none;list-style-image:none;margin:0;padding:0;}
-img{border:0;-ms-interpolation-mode:bicubic;vertical-align:middle;}
-svg:not(:root){overflow:hidden;}
-figure{margin:0;}
-form{margin:0;}
-fieldset{border:0;margin:0;padding:0;}
-label{cursor:pointer;}
-legend{border:0;*margin-left:-7px;padding:0;white-space:normal;}
-button,input,select,textarea{font-size:100%;margin:0;vertical-align:baseline;*vertical-align:middle;}
-button,input{line-height:normal;}
-button,input[type="button"],input[type="reset"],input[type="submit"]{cursor:pointer;-webkit-appearance:button;*overflow:visible;}
-button[disabled],input[disabled]{cursor:default;}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0;*width:13px;*height:13px;}
-input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box;}
-input[type="search"]::-webkit-search-decoration,input[type="search"]::-webkit-search-cancel-button{-webkit-appearance:none;}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0;}
-textarea{overflow:auto;vertical-align:top;resize:vertical;}
-input:invalid,textarea:invalid{background-color:#f0dddd;}
-table{border-collapse:collapse;border-spacing:0;}
-td{vertical-align:top;}
-.chromeframe{margin:.2em 0;background:#ccc;color:black;padding:0.2em 0;}
-.clearfix:before,.clearfix:after{content:"";display:table;}
-.clearfix:after{clear:both;}
-.clearfix{*zoom:1;}
-body{font-family:'open-sans','Open Sans',sans-serif;font-size:100%;line-height:1.618;}
-a,a:visited{font-weight:600;text-decoration:none;padding-bottom:0.132em;}
-h1,h2,h3{font-size:3.375em;margin:0;letter-spacing:-0.06em;font-weight:600;}
-h4{font-size:1em;font-weight:bold;}
-p{margin:0.667em 0;}
-blockquote{font-style:italic;margin:1em 2em;}blockquote +p{margin:1em 2em;}
-dt{font-weight:bold;}
-figure{padding-left:1em;margin-left:1em;border-left:1px solid rgba(0, 0, 0, 0.1);}
-figcaption h4,figcaption p{margin:0.5em 0;}
-small{font-size:0.667em;text-transform:uppercase;}
-.example{padding:1em;border:1px solid rgba(0, 0, 0, 0.1);}
-code{color:#792;}
-ol.code{color:#999;font:0.875em/1.7143 Menlo,Monaco,'Courier New',Courier,monospace;}ol.code li{list-style:decimal-leading-zero;background:#f0f0f0;margin:0 0 -1px 0;border-top:1px solid #fff;padding:0 0.5em;}ol.code li code{font-size:1em;}
-.branding h1,.branding h2,.event h1,.event h2,.event h3{line-height:1.05;}
-.event header h1{font-size:5.063em;margin-left:-3px;}
-.upcoming .event .type{font-weight:bold;}
-.upcoming .h2{font-weight:normal;}
-section h1{text-transform:uppercase;margin-left:-3px;}
-section h2,section h3{font-size:2.25em;font-weight:100;}
-.photos .more a{font-weight:100;font-size:1em;}
-menu h3{line-height:1.618;margin-left:0;font-size:1.5em;position:relative;text-transform:uppercase;}
-header nav a{font-weight:400;text-transform:uppercase;}
-footer .footer{font-size:0.667em;}
-[class^="icon-"]:before,[class*=" icon-"]:before,.tweet:before{font-family:'Pictos Custom';font-style:normal;font-weight:normal;display:inline-block;vertical-align:middle;text-decoration:inherit;font-size:1.5em;padding-right:0.25em;-webkit-font-smoothing:antialiased;content:'';}
-.tweet:before{float:left;padding-right:0.5em;}
-[data-icon]:before{font-family:'Pictos Custom';font-style:normal;font-weight:normal;display:inline-block;vertical-align:middle;text-decoration:inherit;font-size:1.5em;padding-right:0.25em;-webkit-font-smoothing:antialiased;content:attr(data-icon);speak:none;}
-.icon-top:before{content:'⇧';}
-body{background:#ffffff;color:#444444;-webkit-font-smoothing:antialiased;}
-a,a:visited{-webkit-transition:all .1s linear;transition:all .1s linear;color:#2b2b2b;}
-a:hover,a:active{color:#444444;border-bottom:0.088em solid #444444;}
-p a{border-bottom:0.088em dotted #2b2b2b;}
-::-moz-selection{color:white;background:#a5ca4e;}
-::selection{color:white;background:#a5ca4e;}
-header nav a,header nav a:visited{background:#e9e9e9;outline:none;border-left:0.444em solid #f3f3f3;}
-header nav a:hover,header nav a:active{border-bottom:none;background:#dfdfdf;}
-.branding{color:#444444;}.branding h2{color:#444444;}
-.event h2{color:#444444;}
-.event .date,.event .location,.event .synopsis{color:#cacaca;}
-.event .synopsis{margin-top:1em;font-weight:normal;font-size:1.5em;}
-.upcoming h2{color:#444444;}
-.upcoming nav a{background-color:#e9e9e9;}.upcoming nav a:hover{background-color:#dfdfdf;}
-.multipack.event,.multipack.tweet{background-color:#a5ca4e;color:#f3f3f3;}
-.multipack.branding{color:#a5ca4e;}.multipack.branding h2{color:#7e8e57;}
-.multipack.event h2,.multipack.tweet footer{color:#f3f3f3;}
-.multipack.event .date,.multipack.event .location,.multipack.event .synopsis{color:#506917;}
-.multipack.event .type{color:#ffffff;}
-.multipack.event a,.multipack.event a:visited{color:#506917;border-color:#506917;}
-.multipack.event nav a,.multipack.tweet a{color:#506917;border-color:#506917;background-color:#afd062;}
-.multipack.event nav a:hover,.multipack.tweet a:hover{background-color:#b9d676;border-bottom:none;}
-.multipack.tweet:before{color:#506917;}
-.leampack.event,.leampack.tweet{background-color:#43aad6;color:#f3f3f3;}
-.leampack.branding{color:#43aad6;}.leampack.branding h2{color:#4c829a;}
-.leampack.event h2,.leampack.tweet footer{color:#f3f3f3;}
-.leampack.event .date,.leampack.event .location,.leampack.event .synopsis{color:#11536f;}
-.leampack.event .type{color:#ffffff;}
-.leampack.event a,.leampack.event a:visited{color:#0d4259;border-color:#0d4259;}
-.leampack.event nav a,.leampack.tweet a{color:#0d4259;background-color:#2ea0d1;}
-.leampack.event nav a:hover,.leampack.tweet a:hover{background-color:#2b97c5;border-bottom:none;}
-.leampack.tweet:before{color:#0d4259;}
-.presents.event,.presents.tweet{background-color:#d66f43;color:#f3f3f3;}
-.presents.branding{color:#d66f43;}.presents.branding h2{color:#9a634c;}
-.presents.event h2,.presents.tweet footer{color:#f3f3f3;}
-.presents.event .date,.presents.event .location,.presents.event .synopsis{color:#6f2d11;}
-.presents.event .type{color:#ffffff;}
-.presents.event a,.presents.event a:visited{color:#9a634c;border-color:#9a634c;}
-.presents.event nav a,.presents.tweet a{color:#9a634c;background-color:#d8754b;}
-.presents.event nav a:hover,.presents.tweet a:hover{background-color:#da7f58;border-bottom:none;}
-.presents.tweet:before{color:#9a634c;}
-section{border-top:.1875em solid white;background:#f3f3f3;}section[role=color]{box-shadow:0 -4px 6px -4px rgba(0, 0, 0, 0.2);}
-section h2{color:#7e8e57;}
-nav .multipack a:hover{border-color:#a5ca4e;}
-nav .leampack a:hover{border-color:#43aad6;}
-nav .presents a:hover{text-decoration:line-through;border-color:#d66f43;background-color:#e9e9e9;}
-.photos li{background:#e9e9e9;}.photos li a:hover{background:#cacaca;}
-.photos li img{box-shadow:0 1px 3px #cacaca;box-shadow:0 1px 3px rgba(0, 0, 0, 0.2);}
-.photos li .more a{color:#7e8e57;}
-.newsletter input[type=email]{background:#dfdfdf;}
-.newsletter input[type=email]:focus{outline:1px solid #a5ca4e;}
-.newsletter input[type=submit]{background:#a5ca4e;}
-.newsletter input[type=submit]:hover{background-color:#8cb135;}
-.top,.top:visited{background:#e9e9e9;background:rgba(0, 0, 0, 0.2);color:#2b2b2b;}.top:hover,.top:visited:hover,.top:active,.top:visited:active{background:rgba(0, 0, 0, 0.3);color:#444444;border-bottom:none;}
-.extra{display:none;}
-.focus .extra{display:block;}
-.photos{margin:1.5em 0 0;}.photos ul{margin:0;overflow:hidden;list-style:none;padding-left:0;}
-.photos li{float:left;margin-right:0.44em;margin-bottom:0.44em;width:18%;}.photos li a{display:block;padding:0.444em;max-width:100%;}.photos li a:hover{border-bottom:none;}
-.photos .more{margin:0;}.photos .more a{color:#8c9ca3;font-weight:100;font-size:1em;}
-.iframe{position:relative;padding-bottom:53.25%;padding-top:30px;height:0;overflow:hidden;width:100%;}
-.iframe iframe{position:absolute;top:0;left:0;width:100%;height:100%;}
-.container{width:73.4375%;margin:0 auto;}
-section>article{margin-bottom:3.375em;}
-.event{padding:3.375em 19.3882979%;}.event header,.event footer{text-transform:uppercase;}
-.event header h1{text-indent:-9999px;background:transparent url(../img/bull-white.png) no-repeat 3px bottom;}
-.event header p{margin-bottom:0;}
-.event nav{margin-top:1em;}.event nav ul{overflow:hidden;}
-.event nav li{float:left;margin-right:1em;padding-bottom:0.444em;}
-.event nav a{padding:3px .444em 3px;display:block;}
-.event .findmore{display:none;margin-right:0;}
-.event .findless{float:right;margin-right:0;}
-.event .map{display:none;}
-.event h2{display:inline;}
-.event h2.type{display:block;text-transform:uppercase;}
-.event.focus{border-top:.1875em solid white;}.event.focus.next{border-top:none;}
-.event.focus .eventfocus{display:none;}
-.event.focus .map.iframe{display:block;}
-.folded{overflow:hidden;padding:1.5em 19.3882979%;}.folded header h1{border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px;}
-.folded header p{margin-top:0;}
-.folded h2{font-size:1.5em;display:block;float:left;margin-right:0.667em;}
-.folded .time,.folded .location,.folded .extra,.folded .map{border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px;}
-.folded nav{margin-top:0;float:right;}
-.folded ul li{padding:0;}
-.folded ul li:not(.findmore){border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px;}
-.folded .findmore{display:block;}
-.folded .details{float:left;}
-.folded .date,.folded .venue{font-weight:normal;}
-.folded .venue{padding-bottom:0.148em;max-width:30%;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;}
-.upcoming h3{margin-bottom:0.667em;}
-.upcoming ul{list-style:none;padding-left:0;}
-.upcoming .venue{padding-bottom:0.148em;max-width:25%;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;}
-.upcoming .event{display:block;margin-bottom:0.444em;box-shadow:inset 0 0 0.444 rgba(0, 0, 0, 0.2);border-bottom:1px solid #ffffff;padding:1.5em 1.5em;}
-.upcoming .event header p{margin-top:0;}
-.upcoming .event.folded header{border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px;}
-.upcoming .event .synopsis{font-size:1em;margin-top:0.667em;}
-.upcoming .event nav a:hover{border-bottom:none;}
-.upcoming .event:not(.folded) .extra{display:block;}
-section{padding:3.375em 19.3882979%;}section header{overflow:hidden;}section header h1{padding-top:1.75em;background:transparent url(../img/bull-dark.png) no-repeat 3px 0.262em;}
-section header .branding{max-width:500px;padding-bottom:0.444em;}
-section .about{margin-top:2.25em;display:none;}
-section .map{margin-top:1em;}
-section .mapimage{margin-top:1em;display:none;}
-section header nav,footer header nav{margin-bottom:1.5em;overflow:hidden;}section header nav .nav-col,footer header nav .nav-col{float:left;width:50%;}
-section header nav ul,footer header nav ul{overflow:hidden;}
-section header nav li,footer header nav li{margin:0.444em 0;text-align:left;}
-section header nav a,footer header nav a{padding:3px .444em 3px;}
-footer .social{overflow:hidden;}
-footer .tweets{padding-top:1em;}footer .tweets ul{padding:0;margin:0;}
-footer .tweet{background-repeat:no-repeat;overflow:hidden;display:block;margin-bottom:0.444em;border-bottom:1px solid white;padding:1.5em 1.5em;}footer .tweet blockquote{margin:0;overflow:hidden;}
-footer .tweet h2{font-style:normal;padding:0 1em 0 2.5em;padding-left:0;font-size:1em;font-weight:bold;line-height:1.5;float:left;}
-footer .tweet time{display:block;font-size:0.667em;font-style:normal;margin-top:0.444em;}
-footer .tweet p{font-style:italic;overflow:hidden;color:white;margin:3px 0 0;}footer .tweet p a{padding:0 0.262em;border-bottom:none;}
-footer .tweet .follow{padding:3px .444em 3px;display:block;float:left;}
-footer .social article{margin-bottom:0;}
-footer .social-media{width:50%;float:left;overflow:hidden;}footer .social-media h4{margin:0.9em 0;}
-footer .social-media ul{padding-left:0;list-style:none;overflow:hidden;}footer .social-media ul li{display:block;width:50%;float:left;margin-bottom:0.296em;}
-footer .social-media a{color:#8c9ca3;display:block;}footer .social-media a:hover{color:#295566;border-bottom:none;}
-footer .newsletter input[type=email]{border:none;padding:0.198em 0.296em;}
-footer .newsletter input[type=submit]{border:none;color:white;font-size:0.667em;text-transform:uppercase;padding:0.56em;position:relative;top:-2px;}
-footer .newsletter aside{font-size:0.667em;margin-top:1em;}
-footer .share ul{list-style:none;padding-left:0;overflow:hidden;}footer .share ul li{display:block;float:left;margin-right:0.667em;}
-footer .footer{overflow:hidden;}footer .footer a,footer .footer a:hover{border-width:1px;}
-footer .footer .copyright{float:left;}
-footer .footer .feed{float:right;}
-footer .footer .license{clear:both;}
-.top{opacity:0;display:block;position:fixed;top:0px;left:0px;padding:0.1em 0;width:8.666666%;max-width:2.5em;text-align:center;cursor:pointer;-webkit-transition:all 0.1s linear, opacity 2s linear;-moz-transition:all 0.1s linear, opacity 2s linear;-o-transition:all 0.1s linear, opacity 2s linear;transition:all 0.1s linear, opacity 2s linear;}.top:before{position:relative;top:1px;left:1px;}
-form div{margin-bottom:0.5em;}
-input{font-family:'open-sans','Open Sans',sans-serif;}
-::-webkit-validation-bubble-message{font-family:'open-sans','Open Sans',sans-serif;font-size:1em;padding:0.3em 0.667em;padding-left:0.444em;box-shadow:0 3px 2px -3px rgba(0, 0, 0, 0.2);}
-.backgroundsize.svg section header h1{background:transparent url(../img/bull-dark.svg) no-repeat 0 top;-o-background-size:2em auto;-moz-background-size:2em auto;-webkit-background-size:2em auto;background-size:2em auto;}
-.backgroundsize.svg .event header h1{background:transparent url(../img/bull-white.svg) no-repeat 0 bottom;-o-background-size:1.2em auto;-moz-background-size:1.2em auto;-webkit-background-size:1.2em auto;background-size:1.2em auto;}
-.backgroundsize.svg .upcoming .event header h1{-o-background-size:1.2em auto;-moz-background-size:1.2em auto;-webkit-background-size:1.2em auto;background-size:1.2em auto;}
-img,object,video{max-width:100%;}
-@media screen and (max-width:1400px){.event,section{padding-left:8.617021277%;padding-right:8.617021277%;} .upcoming .folded.event .venue{max-width:42%;}}@media screen and (max-width:1024px){.container{width:auto;margin:0;} .upcoming .folded.event .venue{max-width:42%;}}@media screen and (max-width:820px){.upcoming .folded.event .venue{max-width:29%;}}@media screen and (max-width:680px){.folded.event .venue{display:none;} .social-media{width:auto;float:none;} form div{margin-bottom:1em;}form div em{display:block;margin-bottom:0.5em;} form div textarea{width:95%;} .photos li{width:23%;} .top{display:block;}}@media screen and (max-device-width:480px),screen and (max-width:480px){body{font-size:0.9em;} .event{font-size:0.8em;}.event header h1{font-size:6em;} .event .findless{float:left;} .event.focus .map.iframe{display:none;} .event.focus .mapimage{display:block;} .folded{font-size:1em;}.folded a{font-size:0.8em;} .folded h2{margin-right:0.667em;font-size:1em;padding:.444em 0 3px;} section h3{font-size:1.5em;} .tweet h2{margin-bottom:0.5em;} .tweet p{clear:both;} footer .social-media,footer .newsletter{float:none;width:auto;}}
+/*
+ * HTML5 ✰ Boilerplate
+ */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+nav,
+section {
+  display: block;
+}
+audio,
+canvas,
+video {
+  display: inline-block;
+  *display: inline;
+  *zoom: 1;
+}
+audio:not([controls]) {
+  display: none;
+}
+[hidden] {
+  display: none;
+}
+html {
+  font-size: 100%;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+}
+html,
+button,
+input,
+select,
+textarea {
+  font-family: sans-serif;
+  color: #222222;
+}
+body {
+  margin: 0;
+  font-size: 1em;
+  line-height: 1.4;
+}
+::-moz-selection {
+  background: #fe57a1;
+  color: #fff;
+  text-shadow: none;
+}
+::selection {
+  background: #fe57a1;
+  color: #fff;
+  text-shadow: none;
+}
+a {
+  color: #0000ee;
+}
+a:visited {
+  color: #551a8b;
+}
+a:hover {
+  color: #0066ee;
+}
+a:focus {
+  outline: thin dotted;
+}
+a:hover,
+a:active {
+  outline: 0;
+}
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+b,
+strong {
+  font-weight: bold;
+}
+blockquote {
+  margin: 1em 40px;
+}
+dfn {
+  font-style: italic;
+}
+hr {
+  display: block;
+  height: 1px;
+  border: 0;
+  border-top: 1px solid #ccc;
+  margin: 1em 0;
+  padding: 0;
+}
+ins {
+  background: #ff9;
+  color: #000;
+  text-decoration: none;
+}
+mark {
+  background: #ff0;
+  color: #000;
+  font-style: italic;
+  font-weight: bold;
+}
+pre,
+code,
+kbd,
+samp {
+  font-family: monospace,serif;
+  _font-family: 'courier new', monospace;
+  font-size: 1em;
+}
+pre {
+  white-space: pre;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+q {
+  quotes: none;
+}
+q:before,
+q:after {
+  content: "";
+  content: none;
+}
+small {
+  font-size: 85%;
+}
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sup {
+  top: -0.5em;
+}
+sub {
+  bottom: -0.25em;
+}
+ul,
+ol {
+  margin: 1em 0;
+  padding: 0 0 0 40px;
+}
+dd {
+  margin: 0 0 0 40px;
+}
+nav ul,
+nav ol {
+  list-style: none;
+  list-style-image: none;
+  margin: 0;
+  padding: 0;
+}
+img {
+  border: 0;
+  -ms-interpolation-mode: bicubic;
+  vertical-align: middle;
+}
+svg:not(:root) {
+  overflow: hidden;
+}
+figure {
+  margin: 0;
+}
+form {
+  margin: 0;
+}
+fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+label {
+  cursor: pointer;
+}
+legend {
+  border: 0;
+  *margin-left: -7px;
+  padding: 0;
+  white-space: normal;
+}
+button,
+input,
+select,
+textarea {
+  font-size: 100%;
+  margin: 0;
+  vertical-align: baseline;
+  *vertical-align: middle;
+}
+button,
+input {
+  line-height: normal;
+}
+button,
+input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  cursor: pointer;
+  -webkit-appearance: button;
+  *overflow: visible;
+}
+button[disabled],
+input[disabled] {
+  cursor: default;
+}
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box;
+  padding: 0;
+  *width: 13px;
+  *height: 13px;
+}
+input[type="search"] {
+  -webkit-appearance: textfield;
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box;
+  box-sizing: content-box;
+}
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+}
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+textarea {
+  overflow: auto;
+  vertical-align: top;
+  resize: vertical;
+}
+input:invalid,
+textarea:invalid {
+  background-color: #f0dddd;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+td {
+  vertical-align: top;
+}
+.chromeframe {
+  margin: .2em 0;
+  background: #ccc;
+  color: black;
+  padding: 0.2em 0;
+}
+/* For image replacement */
+/* Hide from both screenreaders and browsers: h5bp.com/u */
+/* Hide only visually, but have it available for screenreaders: h5bp.com/v */
+/* Hide visually and from screenreaders, but maintain layout */
+/* Contain floats: h5bp.com/q */
+.clearfix:before,
+.clearfix:after {
+  content: "";
+  display: table;
+}
+.clearfix:after {
+  clear: both;
+}
+.clearfix {
+  *zoom: 1;
+}
+/* ==|== Multipack ==========================================================
+   Creative Commons BY-NC 3.0
+   ========================================================================== */
+body {
+  font-family: 'open-sans', 'Open Sans', sans-serif;
+  font-size: 100%;
+  /* 16px */
+
+  line-height: 1.618;
+}
+a,
+a:visited {
+  font-weight: 600;
+  text-decoration: none;
+  padding-bottom: 0.132em;
+}
+h1,
+h2,
+h3 {
+  font-size: 3.375em;
+  margin: 0;
+  letter-spacing: -0.06em;
+  font-weight: 600;
+}
+h4 {
+  font-size: 1em;
+  font-weight: bold;
+}
+p {
+  margin: 0.667em 0;
+}
+blockquote {
+  font-style: italic;
+  margin: 1em 2em;
+}
+blockquote  + p {
+  margin: 1em 2em;
+}
+dt {
+  font-weight: bold;
+}
+figure {
+  padding-left: 1em;
+  margin-left: 1em;
+  border-left: 1px solid rgba(0, 0, 0, 0.1);
+}
+figcaption h4,
+figcaption p {
+  margin: 0.5em 0;
+}
+small {
+  font-size: 0.667em;
+  text-transform: uppercase;
+}
+.example {
+  padding: 1em;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+code {
+  color: #792;
+}
+ol.code {
+  color: #999;
+  font: 0.875em/1.7143 Menlo, Monaco, 'Courier New', Courier, monospace;
+}
+ol.code li {
+  list-style: decimal-leading-zero;
+  background: #f0f0f0;
+  margin: 0 0 -1px 0;
+  border-top: 1px solid #fff;
+  padding: 0 0.5em;
+}
+ol.code li code {
+  font-size: 1em;
+}
+.branding h1,
+.branding h2,
+.event h1,
+.event h2,
+.event h3 {
+  line-height: 1.05;
+}
+.event header h1 {
+  font-size: 5.063em;
+  margin-left: -3px;
+}
+.upcoming .event .type {
+  font-weight: bold;
+}
+.upcoming .h2 {
+  font-weight: normal;
+}
+section h1 {
+  text-transform: uppercase;
+  margin-left: -3px;
+}
+section h2,
+section h3 {
+  font-size: 2.25em;
+  font-weight: 100;
+}
+.photos .more a {
+  font-weight: 100;
+  font-size: 1em;
+}
+menu h3 {
+  line-height: 1.618;
+  margin-left: 0;
+  font-size: 1.5em;
+  position: relative;
+  text-transform: uppercase;
+}
+header nav a {
+  font-weight: 400;
+  text-transform: uppercase;
+}
+footer .footer {
+  font-size: 0.667em;
+}
+[class^="icon-"]:before,
+[class*=" icon-"]:before,
+.tweet:before {
+  font-family: 'Pictos Custom';
+  font-style: normal;
+  font-weight: normal;
+  display: inline-block;
+  vertical-align: middle;
+  text-decoration: inherit;
+  font-size: 1.5em;
+  padding-right: 0.25em;
+  -webkit-font-smoothing: antialiased;
+  content: '';
+}
+.tweet:before {
+  float: left;
+  padding-right: 0.5em;
+}
+[data-icon]:before {
+  font-family: 'Pictos Custom';
+  font-style: normal;
+  font-weight: normal;
+  display: inline-block;
+  vertical-align: middle;
+  text-decoration: inherit;
+  font-size: 1.5em;
+  padding-right: 0.25em;
+  -webkit-font-smoothing: antialiased;
+  content: attr(data-icon);
+  speak: none;
+}
+.icon-top:before {
+  content: '⇧';
+}
+body {
+  background: #ffffff;
+  color: #444444;
+  -webkit-font-smoothing: antialiased;
+}
+a,
+a:visited {
+  -webkit-transition: all .1s linear;
+  transition: all .1s linear;
+  color: #2b2b2b;
+}
+a:hover,
+a:active {
+  color: #444444;
+  border-bottom: 0.088em solid #444444;
+}
+p a {
+  border-bottom: 0.088em dotted #2b2b2b;
+}
+::-moz-selection {
+  color: white;
+  background: #a5ca4e;
+}
+::selection {
+  color: white;
+  background: #a5ca4e;
+}
+header nav a,
+header nav a:visited {
+  background: #e9e9e9;
+  outline: none;
+  border-left: 0.444em solid #f3f3f3;
+}
+header nav a:hover,
+header nav a:active {
+  border-bottom: none;
+  background: #dfdfdf;
+}
+.branding {
+  color: #444444;
+}
+.branding h2 {
+  color: #444444;
+}
+/* Event Colours */
+.event h2 {
+  color: #444444;
+}
+.event .date,
+.event .region,
+.event .synopsis {
+  color: #cacaca;
+}
+.event .synopsis {
+  margin-top: 1em;
+  font-weight: normal;
+  font-size: 1.5em;
+}
+.upcoming h2 {
+  color: #444444;
+}
+.upcoming nav a {
+  background-color: #e9e9e9;
+}
+.upcoming nav a:hover {
+  background-color: #dfdfdf;
+}
+/* Multipack */
+.multipack.event,
+.multipack.tweet {
+  background-color: #a5ca4e;
+  color: #f3f3f3;
+}
+.multipack.branding {
+  color: #a5ca4e;
+}
+.multipack.branding h2 {
+  color: #7e8e57;
+}
+.multipack.event h2,
+.multipack.tweet footer {
+  color: #f3f3f3;
+}
+.multipack.event .date,
+.multipack.event .region,
+.multipack.event .synopsis {
+  color: #506917;
+}
+.multipack.event .type {
+  color: #ffffff;
+}
+.multipack.event a,
+.multipack.event a:visited {
+  color: #506917;
+  border-color: #506917;
+}
+.multipack.event nav a,
+.multipack.tweet a {
+  color: #506917;
+  border-color: #506917;
+  background-color: #afd062;
+}
+.multipack.event nav a:hover,
+.multipack.tweet a:hover {
+  background-color: #b9d676;
+  border-bottom: none;
+}
+.multipack.tweet:before {
+  color: #506917;
+}
+/* Leampack */
+.leampack.event,
+.leampack.tweet {
+  background-color: #43aad6;
+  color: #f3f3f3;
+}
+.leampack.branding {
+  color: #43aad6;
+}
+.leampack.branding h2 {
+  color: #4c829a;
+}
+.leampack.event h2,
+.leampack.tweet footer {
+  color: #f3f3f3;
+}
+.leampack.event .date,
+.leampack.event .region,
+.leampack.event .synopsis {
+  color: #11536f;
+}
+.leampack.event .type {
+  color: #ffffff;
+}
+.leampack.event a,
+.leampack.event a:visited {
+  color: #0d4259;
+  border-color: #0d4259;
+}
+.leampack.event nav a,
+.leampack.tweet a {
+  color: #0d4259;
+  background-color: #2ea0d1;
+}
+.leampack.event nav a:hover,
+.leampack.tweet a:hover {
+  background-color: #2b97c5;
+  border-bottom: none;
+}
+.leampack.tweet:before {
+  color: #0d4259;
+}
+/* Staffspack */
+/* Presents */
+.presents.event,
+.presents.tweet {
+  background-color: #d66f43;
+  color: #f3f3f3;
+}
+.presents.branding {
+  color: #d66f43;
+}
+.presents.branding h2 {
+  color: #9a634c;
+}
+.presents.event h2,
+.presents.tweet footer {
+  color: #f3f3f3;
+}
+.presents.event .date,
+.presents.event .region,
+.presents.event .synopsis {
+  color: #6f2d11;
+}
+.presents.event .type {
+  color: #ffffff;
+}
+.presents.event a,
+.presents.event a:visited {
+  color: #9a634c;
+  border-color: #9a634c;
+}
+.presents.event nav a,
+.presents.tweet a {
+  color: #9a634c;
+  background-color: #d8754b;
+}
+.presents.event nav a:hover,
+.presents.tweet a:hover {
+  background-color: #da7f58;
+  border-bottom: none;
+}
+.presents.tweet:before {
+  color: #9a634c;
+}
+section {
+  border-top: .1875em solid white;
+  background: #f3f3f3;
+}
+section[role=color] {
+  box-shadow: 0 -4px 6px -4px rgba(0, 0, 0, 0.2);
+}
+section h2 {
+  color: #7e8e57;
+}
+nav .multipack a:hover {
+  border-color: #a5ca4e;
+}
+nav .leampack a:hover {
+  border-color: #43aad6;
+}
+nav .presents a:hover {
+  text-decoration: line-through;
+  border-color: #d66f43;
+  background-color: #e9e9e9;
+}
+.photos li {
+  background: #e9e9e9;
+}
+.photos li a:hover {
+  background: #cacaca;
+}
+.photos li img {
+  box-shadow: 0 1px 3px #cacaca;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+.photos li .more a {
+  color: #7e8e57;
+}
+.newsletter input[type=email] {
+  background: #dfdfdf;
+}
+.newsletter input[type=email]:focus {
+  outline: 1px solid #a5ca4e;
+}
+.newsletter input[type=submit] {
+  background: #a5ca4e;
+}
+.newsletter input[type=submit]:hover {
+  background-color: #8cb135;
+}
+.top,
+.top:visited {
+  background: #e9e9e9;
+  background: rgba(0, 0, 0, 0.2);
+  color: #2b2b2b;
+}
+.top:hover,
+.top:visited:hover,
+.top:active,
+.top:visited:active {
+  background: rgba(0, 0, 0, 0.3);
+  color: #444444;
+  border-bottom: none;
+}
+/* Utility */
+.extra {
+  display: none;
+}
+.focus .extra {
+  display: block;
+}
+.photos {
+  margin: 1.5em 0 0;
+}
+.photos ul {
+  margin: 0;
+  overflow: hidden;
+  list-style: none;
+  padding-left: 0;
+}
+.photos li {
+  float: left;
+  margin-right: 0.44em;
+  margin-bottom: 0.44em;
+  width: 18%;
+}
+.photos li a {
+  display: block;
+  padding: 0.444em;
+  max-width: 100%;
+}
+.photos li a:hover {
+  border-bottom: none;
+}
+.photos .more {
+  margin: 0;
+}
+.photos .more a {
+  color: #8c9ca3;
+  font-weight: 100;
+  font-size: 1em;
+}
+.iframe {
+  position: relative;
+  padding-bottom: 53.25%;
+  padding-top: 30px;
+  height: 0;
+  overflow: hidden;
+  width: 100%;
+}
+.iframe iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+/* Layout */
+.container {
+  width: 73.4375%;
+  margin: 0 auto;
+}
+section > article {
+  margin-bottom: 3.375em;
+}
+.event {
+  padding: 3.375em 19.3882979%;
+}
+.event header,
+.event footer {
+  text-transform: uppercase;
+}
+.event header h1 {
+  text-indent: -9999px;
+  background: transparent url(../img/bull-white.png) no-repeat 3px bottom;
+}
+.event header p {
+  margin-bottom: 0;
+}
+.event nav {
+  margin-top: 1em;
+}
+.event nav ul {
+  overflow: hidden;
+}
+.event nav li {
+  float: left;
+  margin-right: 1em;
+  padding-bottom: 0.444em;
+}
+.event nav a {
+  padding: 3px .444em 3px;
+  display: block;
+}
+.event .findmore {
+  display: none;
+  margin-right: 0;
+}
+.event .findless {
+  float: right;
+  margin-right: 0;
+}
+.event .map {
+  display: none;
+}
+.event h2 {
+  display: inline;
+}
+.event h2.type {
+  display: block;
+  text-transform: uppercase;
+}
+.event .location {
+  display: inline;
+}
+.event.focus {
+  border-top: .1875em solid white;
+}
+.event.focus.next {
+  border-top: none;
+}
+.event.focus .eventfocus {
+  display: none;
+}
+.event.focus .map.iframe {
+  display: block;
+}
+.folded {
+  overflow: hidden;
+  padding: 1.5em 19.3882979%;
+}
+.folded header h1 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+.folded header p {
+  margin-top: 0;
+}
+.folded h2 {
+  font-size: 1.5em;
+  display: block;
+  float: left;
+  margin-right: 0.667em;
+}
+.folded .time,
+.folded .region,
+.folded .extra,
+.folded .map {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+.folded nav {
+  margin-top: 0;
+  float: right;
+}
+.folded ul li {
+  padding: 0;
+}
+.folded ul li:not(.findmore) {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+.folded .findmore {
+  display: block;
+}
+.folded .details {
+  float: left;
+}
+.folded .date,
+.folded .venue {
+  font-weight: normal;
+}
+.folded .venue {
+  padding-bottom: 0.148em;
+  max-width: 30%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.upcoming h3 {
+  margin-bottom: 0.667em;
+}
+.upcoming ul {
+  list-style: none;
+  padding-left: 0;
+}
+.upcoming .venue {
+  padding-bottom: 0.148em;
+  max-width: 25%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.upcoming .event {
+  display: block;
+  margin-bottom: 0.444em;
+  box-shadow: inset 0 0 0.444 rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid #ffffff;
+  padding: 1.5em 1.5em;
+}
+.upcoming .event header p {
+  margin-top: 0;
+}
+.upcoming .event.folded header {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+.upcoming .event .synopsis {
+  font-size: 1em;
+  margin-top: 0.667em;
+}
+.upcoming .event nav a:hover {
+  border-bottom: none;
+}
+.upcoming .event:not(.folded) .extra {
+  display: block;
+}
+section {
+  padding: 3.375em 19.3882979%;
+}
+section header {
+  overflow: hidden;
+}
+section header h1 {
+  padding-top: 1.75em;
+  background: transparent url(../img/bull-dark.png) no-repeat 3px 0.262em;
+}
+section header .branding {
+  max-width: 500px;
+  padding-bottom: 0.444em;
+}
+section .about {
+  margin-top: 2.25em;
+  display: none;
+}
+section .map {
+  margin-top: 1em;
+}
+section .mapimage {
+  margin-top: 1em;
+  display: none;
+}
+section header nav,
+footer header nav {
+  margin-bottom: 1.5em;
+  overflow: hidden;
+}
+section header nav .nav-col,
+footer header nav .nav-col {
+  float: left;
+  width: 50%;
+}
+section header nav ul,
+footer header nav ul {
+  overflow: hidden;
+}
+section header nav li,
+footer header nav li {
+  margin: 0.444em 0;
+  text-align: left;
+}
+section header nav a,
+footer header nav a {
+  padding: 3px .444em 3px;
+}
+footer .social {
+  overflow: hidden;
+}
+footer .tweets {
+  padding-top: 1em;
+}
+footer .tweets ul {
+  padding: 0;
+  margin: 0;
+}
+footer .tweet {
+  background-repeat: no-repeat;
+  overflow: hidden;
+  display: block;
+  margin-bottom: 0.444em;
+  border-bottom: 1px solid white;
+  padding: 1.5em 1.5em;
+}
+footer .tweet blockquote {
+  margin: 0;
+  overflow: hidden;
+}
+footer .tweet h2 {
+  font-style: normal;
+  padding: 0 1em 0 2.5em;
+  padding-left: 0;
+  font-size: 1em;
+  font-weight: bold;
+  line-height: 1.5;
+  float: left;
+}
+footer .tweet time {
+  display: block;
+  font-size: 0.667em;
+  font-style: normal;
+  margin-top: 0.444em;
+}
+footer .tweet p {
+  font-style: italic;
+  overflow: hidden;
+  color: white;
+  margin: 3px 0 0;
+}
+footer .tweet p a {
+  padding: 0 0.262em;
+  border-bottom: none;
+}
+footer .tweet .follow {
+  padding: 3px .444em 3px;
+  display: block;
+  float: left;
+}
+footer .social article {
+  margin-bottom: 0;
+}
+footer .social-media {
+  width: 50%;
+  float: left;
+  overflow: hidden;
+}
+footer .social-media h4 {
+  margin: 0.9em 0;
+}
+footer .social-media ul {
+  padding-left: 0;
+  list-style: none;
+  overflow: hidden;
+}
+footer .social-media ul li {
+  display: block;
+  width: 50%;
+  float: left;
+  margin-bottom: 0.296em;
+}
+footer .social-media a {
+  color: #8c9ca3;
+  display: block;
+}
+footer .social-media a:hover {
+  color: #295566;
+  border-bottom: none;
+}
+footer .newsletter input[type=email] {
+  border: none;
+  padding: 0.198em 0.296em;
+}
+footer .newsletter input[type=submit] {
+  border: none;
+  color: white;
+  font-size: 0.667em;
+  text-transform: uppercase;
+  padding: 0.56em;
+  position: relative;
+  top: -2px;
+}
+footer .newsletter aside {
+  font-size: 0.667em;
+  margin-top: 1em;
+}
+footer .share ul {
+  list-style: none;
+  padding-left: 0;
+  overflow: hidden;
+}
+footer .share ul li {
+  display: block;
+  float: left;
+  margin-right: 0.667em;
+}
+footer .footer {
+  overflow: hidden;
+}
+footer .footer a,
+footer .footer a:hover {
+  border-width: 1px;
+}
+footer .footer .copyright {
+  float: left;
+}
+footer .footer .feed {
+  float: right;
+}
+footer .footer .license {
+  clear: both;
+}
+.top {
+  opacity: 0;
+  display: block;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  padding: 0.1em 0;
+  width: 8.666666%;
+  max-width: 2.5em;
+  text-align: center;
+  cursor: pointer;
+  -webkit-transition: all 0.1s linear, opacity 2s linear;
+  -moz-transition: all 0.1s linear, opacity 2s linear;
+  -o-transition: all 0.1s linear, opacity 2s linear;
+  transition: all 0.1s linear, opacity 2s linear;
+}
+.top:before {
+  position: relative;
+  top: 1px;
+  left: 1px;
+}
+/* Forms */
+form div {
+  margin-bottom: 0.5em;
+}
+input {
+  font-family: 'open-sans', 'Open Sans', sans-serif;
+}
+::-webkit-validation-bubble-message {
+  font-family: 'open-sans', 'Open Sans', sans-serif;
+  font-size: 1em;
+  padding: 0.3em 0.667em;
+  padding-left: 0.444em;
+  box-shadow: 0 3px 2px -3px rgba(0, 0, 0, 0.2);
+}
+.backgroundsize.svg section header h1 {
+  background: transparent url(../img/bull-dark.svg) no-repeat 0 top;
+  -o-background-size: 2em auto;
+  -moz-background-size: 2em auto;
+  -webkit-background-size: 2em auto;
+  background-size: 2em auto;
+}
+.backgroundsize.svg .event header h1 {
+  background: transparent url(../img/bull-white.svg) no-repeat 0 bottom;
+  -o-background-size: 1.2em auto;
+  -moz-background-size: 1.2em auto;
+  -webkit-background-size: 1.2em auto;
+  background-size: 1.2em auto;
+}
+.backgroundsize.svg .upcoming .event header h1 {
+  -o-background-size: 1.2em auto;
+  -moz-background-size: 1.2em auto;
+  -webkit-background-size: 1.2em auto;
+  background-size: 1.2em auto;
+}
+img,
+object,
+video {
+  max-width: 100%;
+}
+@media screen and (max-width: 1400px) {
+  .event,
+  section {
+    padding-left: 8.617021277%;
+    padding-right: 8.617021277%;
+  }
+  .upcoming .folded.event .venue {
+    max-width: 42%;
+  }
+}
+@media screen and (max-width: 1024px) {
+  .container {
+    width: auto;
+    margin: 0;
+  }
+  .upcoming .folded.event .venue {
+    max-width: 42%;
+  }
+}
+@media screen and (max-width: 820px) {
+  .upcoming .folded.event .venue {
+    max-width: 29%;
+  }
+}
+@media screen and (max-width: 680px) {
+  .folded.event .venue {
+    display: none;
+  }
+  .social-media {
+    width: auto;
+    float: none;
+  }
+  form div {
+    margin-bottom: 1em;
+  }
+  form div em {
+    display: block;
+    margin-bottom: 0.5em;
+  }
+  form div textarea {
+    width: 95%;
+  }
+  .photos li {
+    width: 23%;
+  }
+  .top {
+    display: block;
+  }
+}
+@media screen and (max-device-width: 480px), screen and (max-width: 480px) {
+  body {
+    font-size: 0.9em;
+  }
+  .event {
+    font-size: 0.8em;
+  }
+  .event header h1 {
+    font-size: 6em;
+  }
+  .event .findless {
+    float: left;
+  }
+  .event.focus .map.iframe {
+    display: none;
+  }
+  .event.focus .mapimage {
+    display: block;
+  }
+  .folded {
+    font-size: 1em;
+  }
+  .folded a {
+    font-size: 0.8em;
+  }
+  .folded h2 {
+    margin-right: 0.667em;
+    font-size: 1em;
+    padding: .444em 0 3px;
+  }
+  section h3 {
+    font-size: 1.5em;
+  }
+  .tweet h2 {
+    margin-bottom: 0.5em;
+  }
+  .tweet p {
+    clear: both;
+  }
+  footer .social-media,
+  footer .newsletter {
+    float: none;
+    width: auto;
+  }
+}

--- a/index.php
+++ b/index.php
@@ -93,7 +93,7 @@ $model = new Store();
 // Lanyrd API is a model
 $model->lanyrd = new Lanyrd();
 //$model->cache = new Cache();
-Cache::setPath(DIR_APP . '/cache');
+Cache::setPath('/tmp');
 
 /**
  * Controller


### PR DESCRIPTION
- Schema.org event types on event details
- Updates to markup to support itemscopes
- Reworked extract_event to parse dates into DateTime objects with
  correct timezone

This changes the event markup from

``` HTML
<article role="details">
  <h2 class="type">leampack</h2>
  <h2 class="date">29 May</h2>
  <h2 class="venue">The White Horse</h2>
  <h2 class="location">Leamington</h2>
  <h2 class="time">7:30pm</h2>
</article>
…
```

to

``` HTML
<div itemscope itemtype="http://schema.org/SocialEvent/Meetup">
  <article role="details">
    <h2 class="type" itemprop="name">leampack</h2>
    <h2 class="date"><time itemprop="startDate" datetime="2012-05-29T19:30:00+01:00">29 May</time></h2>
    <div class="location" itemprop="location" itemscope itemtype="http://schema.org/Place">
      <h2 class="venue" itemprop="name">The White Horse</h2>
      <h2 class="region" itemprop="containedIn" itemscope itemtype="http://schema.org/AdministrativeArea"><span itemprop="name">Leamington</span></h2>
      <meta itemprop="map" content="http://maps.google.com/maps?q=52.2934915623%2C-1.53812362806+%28The+White+Horse%29">
    </div>
    <h2 class="time">7:30pm</h2>
  </article>
  …
</div>
```
