### PR TITLE
Use GitHub Pages action workflow

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -37,7 +37,6 @@ module.exports = function (eleventy) {
   return {
     dir: {
       input: 'src',
-      output: 'www',
       includes: 'includes',
       layouts: 'layouts',
       data: 'data'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,46 @@
 name: Deploy
+
 on:
   push:
     branches:
-      - main
+      - [$default-branch]
+
+  # Enable running this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Build
-      run: |
-        npm install
-        npm run-script build
-    - name: Deploy
-      uses: JamesIves/github-pages-deploy-action@releases/v3
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: www
+      uses: actions/checkout@v3
+    - name: Setup Pages
+      uses: actions/configure-pages@v2
+    - name: Install dependencies
+      run: npm ci
+    - name: Build with Eleventy
+      run: npm run-script build
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
+_site
 logs
 node_modules
-www
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -14,11 +14,8 @@ the project.
 ```bash
 npm run watch
 npm run build
-npm run deploy
 ```
 
 ## Deploying
 
-The website is hosted using Github Pages using the specific `gh-pages` branch.
-
-Eleventy can be compiled and deployed using `npm run deploy`
+The website is automatically deployed to Github Pages using the [`deploy`](/.github/workflows/deploy.yml) workflow.

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "lint:scripts": "eslint *.js",
     "lint:styles": "stylelint src/**/*.css",
     "lint": "npm-run-all lint:*",
-    "debug": "DEBUG=* npx eleventy",
-    "deploy": "npm run build && push-dir --dir=www --branch=gh-pages --force"
+    "debug": "DEBUG=* npx eleventy"
   },
   "dependencies": {
     "@11ty/eleventy": "^1.0.2",
@@ -33,8 +32,7 @@
     "postcss-cli": "^10.0.0",
     "postcss-custom-selectors": "^6.0.0",
     "postcss-easy-import": "^4.0.0",
-    "postcss-extend-rule": "^4.0.0",
-    "push-dir": "^0.4.1"
+    "postcss-extend-rule": "^4.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.0",


### PR DESCRIPTION
GitHub now provides support for deploying to GitHub Pages using GitHub Actions. This PR attempts to use this approach. (Think I’ll need to merge this to the default branch and cross my fingers that it works!)