### PR TITLE
feat: add contributors to package.json and use them in humans.txt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,28 @@
 {
   "name": "multipack",
   "version": "0.0.1",
+  "private": true,
   "description": "A community of web designers and developers in the West Midlands.",
   "homepage": "https://multipack.co.uk",
-  "author": "Trevor Morris",
+  "author": "Multipack",
+  "contributors": [
+    {
+      "name": "Trevor Morris",
+      "url": "https://www.trovster.com"
+    },
+    {
+      "name": "Paul Robert Lloyd",
+      "url": "https://paulrobertlloyd.com"
+    },
+    {
+      "name": "Si Jobling",
+      "url": "https://sijobling.com"
+    },
+    {
+      "name": "Andrew Yates",
+      "url": "https://www.andydev.co.uk"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/multipack/website.git"
@@ -39,7 +58,6 @@
   "engines": {
     "node": "^18.11.0"
   },
-  "private": true,
   "lint-staged": {
     "*.js": [
       "npm run lint:js"

--- a/src/humans.txt.liquid
+++ b/src/humans.txt.liquid
@@ -4,11 +4,12 @@ permalink: /humans.txt
 /* the humans responsible & colophon */
 /* humanstxt.org */
 
-/* MULTIPACK */
-  Trevor Morris
-  @trovster
-  https://www.trovster.com
+/* TEAM */
+{% for contributor in pkg.contributors %}
+  Contributor: {{ contributor.name }}
+  Site: {{ contributor.url }}
+{% endfor %}
 
-  Paul Robert Lloyd
-  @paulrobertlloyd
-  https://paulrobertlloyd.com
+/* SITE */
+  Doctype: HTML5
+  Components: Eleventy, liquid, svg

--- a/src/layouts/default.liquid
+++ b/src/layouts/default.liquid
@@ -23,6 +23,7 @@
 
   <link rel="canonical" href="{{ page.url }}">
   <link rel="manifest" href="/app.webmanifest">
+  <link rel="author" href="/humans.txt" type="text/plain">
   <link rel="stylesheet" href="/assets/styles/app.css">
 
   <link rel="apple-touch-icon" href="{{ app.icon }}">


### PR DESCRIPTION
This adds recent contributors to the `package.json` file, then exposes them as contributors in the `humans.txt` file as per https://humanstxt.org/Standard.html